### PR TITLE
Fix handling of importpath passed as command-line parameter

### DIFF
--- a/src/bench/main.cpp
+++ b/src/bench/main.cpp
@@ -123,6 +123,7 @@ int main(int argc, char** argv)
     }
     if(!options.importPaths.isEmpty()) {
         //qDebug() << "set importPaths: " << options.importPaths;
+        win.addDefaultImportPaths(options.importPaths);
         win.setImportPaths(options.importPaths);
     }
     if(!options.activeDocument.isEmpty()) {

--- a/src/bench/mainwindow.cpp
+++ b/src/bench/mainwindow.cpp
@@ -339,6 +339,11 @@ void MainWindow::setImportPaths(const QStringList &pathList)
     m_node->setImportPaths(pathList + m_qmlDefaultimportList);
 }
 
+void MainWindow::addDefaultImportPaths(const QStringList &pathList)
+{
+	m_qmlDefaultimportList.append(pathList);
+}
+
 void MainWindow::setStaysOnTop(bool enabled)
 {
     m_stayOnTop->setChecked(enabled);

--- a/src/bench/mainwindow.h
+++ b/src/bench/mainwindow.h
@@ -47,6 +47,7 @@ public:
     void setWorkspace(const QString& path);
     void setPluginPath(const QString& path);
     void setImportPaths(const QStringList& pathList);
+    void addDefaultImportPaths(const QStringList& pathList);
     void setStaysOnTop(bool enabled);
     void readSettings();
 protected:


### PR DESCRIPTION
Those parameters used to be lost when reloading a QML from the bench. This commit fixes the issue.
