### PR TITLE
Parse import paths before setting active document

### DIFF
--- a/src/bench/mainwindow.cpp
+++ b/src/bench/mainwindow.cpp
@@ -225,6 +225,8 @@ void MainWindow::readSettings()
 
     updateRecentFolder();
 
+    resetImportPaths();
+
     //Only set the workspace if we didn't already set it by command line
     if (m_workspace->activeDocument().isEmpty()) {
         if (s.contains("activeDocument"))
@@ -232,8 +234,6 @@ void MainWindow::readSettings()
         else
             m_workspace->activateRootPath();
     }
-
-    resetImportPaths();
 
     m_hostModel->restoreFromSettings(&s);
     restoreState(s.value("windowState").toByteArray());


### PR DESCRIPTION
This fixes the issue where you need to press refresh on first load if you are using non-standard import paths.
